### PR TITLE
Added support for custom API host

### DIFF
--- a/ai/engine.go
+++ b/ai/engine.go
@@ -36,6 +36,9 @@ func NewEngine(mode EngineMode, config *config.Config) (*Engine, error) {
 	if config.GetAiConfig().GetProxy() != "" {
 
 		clientConfig := openai.DefaultConfig(config.GetAiConfig().GetKey())
+    if config.GetAiConfig().GetHost() != "" {
+      clientConfig.BaseURL = config.GetAiConfig().GetHost()
+    }
 
 		proxyUrl, err := url.Parse(config.GetAiConfig().GetProxy())
 		if err != nil {
@@ -52,7 +55,12 @@ func NewEngine(mode EngineMode, config *config.Config) (*Engine, error) {
 
 		client = openai.NewClientWithConfig(clientConfig)
 	} else {
-		client = openai.NewClient(config.GetAiConfig().GetKey())
+
+		clientConfig := openai.DefaultConfig(config.GetAiConfig().GetKey())
+    if config.GetAiConfig().GetHost() != "" {
+      clientConfig.BaseURL = config.GetAiConfig().GetHost()
+    }
+		client = openai.NewClientWithConfig(clientConfig)
 	}
 
 	return &Engine{

--- a/config/ai.go
+++ b/config/ai.go
@@ -1,6 +1,7 @@
 package config
 
 const (
+  openai_host        = "OPENAI_HOST"
 	openai_key         = "OPENAI_KEY"
 	openai_model       = "OPENAI_MODEL"
 	openai_proxy       = "OPENAI_PROXY"
@@ -9,11 +10,16 @@ const (
 )
 
 type AiConfig struct {
+  host        string
 	key         string
 	model       string
 	proxy       string
 	temperature float64
 	maxTokens   int
+}
+
+func (c AiConfig) GetHost() string {
+  return c.host
 }
 
 func (c AiConfig) GetKey() string {

--- a/config/ai_test.go
+++ b/config/ai_test.go
@@ -7,10 +7,20 @@ import (
 )
 
 func TestAiConfig(t *testing.T) {
+  t.Run("GetHost", testGetHost)
 	t.Run("GetKey", testGetKey)
 	t.Run("GetProxy", testGetProxy)
 	t.Run("GetTemperature", testGetTemperature)
 	t.Run("GetMaxTokens", testGetMaxTokens)
+}
+
+func testGetHost(t *testing.T) {
+  expectedHost := "https://api.openai.com/v1"
+  aiConfig := AiConfig{host: expectedHost}
+
+  actualHost := aiConfig.GetHost()
+
+  assert.Equal(t, expectedHost, actualHost, "The two hosts should be the same.")
 }
 
 func testGetKey(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		ai: AiConfig{
+      host:        viper.GetString(openai_host),
 			key:         viper.GetString(openai_key),
 			model:       viper.GetString(openai_model),
 			proxy:       viper.GetString(openai_proxy),
@@ -58,6 +59,7 @@ func WriteConfig(key string, write bool) (*Config, error) {
 	system := system.Analyse()
 
 	// ai defaults
+  viper.Set(openai_host, "https://api.openai.com/v1")
 	viper.Set(openai_key, key)
 	viper.Set(openai_model, openai.GPT3Dot5Turbo)
 	viper.SetDefault(openai_proxy, "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ func setupViper(t *testing.T) {
 
 	viper.SetConfigName(strings.ToLower(system.GetApplicationName()))
 	viper.AddConfigPath("/tmp/")
+  viper.Set(openai_host, "https://api.openai.com/v1")
 	viper.Set(openai_key, "test_key")
 	viper.Set(openai_model, openai.GPT3Dot5Turbo)
 	viper.Set(openai_proxy, "test_proxy")
@@ -47,6 +48,7 @@ func testNewConfig(t *testing.T) {
 	cfg, err := NewConfig()
 	require.NoError(t, err)
 
+  assert.Equal(t, "https://api.openai.com/v1", cfg.GetAiConfig().GetHost())
 	assert.Equal(t, "test_key", cfg.GetAiConfig().GetKey())
 	assert.Equal(t, openai.GPT3Dot5Turbo, cfg.GetAiConfig().GetModel())
 	assert.Equal(t, "test_proxy", cfg.GetAiConfig().GetProxy())
@@ -65,6 +67,7 @@ func testWriteConfig(t *testing.T) {
 	cfg, err := WriteConfig("new_test_key", false)
 	require.NoError(t, err)
 
+  assert.Equal(t, "https://api.openai.com/v1", cfg.GetAiConfig().GetHost())
 	assert.Equal(t, "new_test_key", cfg.GetAiConfig().GetKey())
 	assert.Equal(t, openai.GPT3Dot5Turbo, cfg.GetAiConfig().GetModel())
 	assert.Equal(t, "test_proxy", cfg.GetAiConfig().GetProxy())
@@ -75,6 +78,7 @@ func testWriteConfig(t *testing.T) {
 
 	assert.NotNil(t, cfg.GetSystemConfig())
 
+  assert.Equal(t, "https://api.openai.com/v1", cfg.GetAiConfig().GetHost())
 	assert.Equal(t, "new_test_key", viper.GetString(openai_key))
 	assert.Equal(t, openai.GPT3Dot5Turbo, viper.GetString(openai_model))
 	assert.Equal(t, "test_proxy", viper.GetString(openai_proxy))


### PR DESCRIPTION
I have very limited expirience with Go but I really want to use yai with local LLM's so I tried to implement support for custom API host and seemingly succeeded.

It is possible because [Ollama](https://ollama.com)(open source program that allows to run LLM's locally) recently added Openai API compatibility and now all programs written for OpenAI's API that allow to edit API host can run using local LLM's.

Because of my limited expirience with go and lacking familiarity with this project's codebase I am not sure if I implemented everything correctly strongly advise to review this PR carefully and add anything that I forgot to(if I did) before merging.

I feel like my expirience is not enough to implement custom system prompts without actually learning the language. But people who run local LLM's will appreciate if you do implement custom system prompts because some system prompts that are beneficial for ChatGPT are confusing for smaller and dumber 7b models. If custom system prompts are implemented people will be able to fine tune their prompts for the model that they use.